### PR TITLE
Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">Empowerment Programming in TypeScript</p>
 
-# ts-empower
-This library is an attempt to reproduce the functionality of Rust in TypeScript
-However, the goal is not to reproduce them completely, but to implement them in an easy-to-use manner in TypeScript
+<h1>ts-empower</h1>
+
+<p>This library is an attempt to reproduce the functionality of Rust in TypeScript</p>
+<p>However, the goal is not to reproduce them completely, but to implement them in an easy-to-use manner in TypeScript</p>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<center>Empowerment Programming in TypeScript</center>
+<p align="center">Empowerment Programming in TypeScript</p>
 
-# ep-ts
+# ts-empower
 This library is an attempt to reproduce the functionality of Rust in TypeScript
 However, the goal is not to reproduce them completely, but to implement them in an easy-to-use manner in TypeScript

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ep-ts",
+  "name": "ts-empower",
   "version": "1.0.0",
   "description": "Rust saikyo!",
   "main": "./index.js",

--- a/example/ioError.ts
+++ b/example/ioError.ts
@@ -1,4 +1,4 @@
-import { Result, Err, Ok } from "ep-ts";
+import { Result, Err, Ok } from "ts-empower";
 import { readFile } from "node:fs/promises";
 
 class IOError extends Error {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ep-ts",
+  "name": "ts-empower",
   "version": "1.0.0",
   "description": "Rust saikyo!",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.28.1",
     "prettier": "^3.0.3",
-    "ep-ts": "file:dist",
+    "ts-empower": "file:dist",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ devDependencies:
   prettier:
     specifier: ^3.0.3
     version: 3.0.3
-  ep-ts:
+  ts-empower:
     specifier: file:dist
     version: file:dist
   tslib:
@@ -2060,5 +2060,5 @@ packages:
 
   file:dist:
     resolution: {directory: dist, type: directory}
-    name: ep-ts
+    name: ts-empower
     dev: true


### PR DESCRIPTION
`ep-ts`が`fp-ts`に似過ぎている！死刑！とnpmさんに怒られてしまった・・・
なので、代替案として`ts-empower`はどうだろうかと試す。